### PR TITLE
Load next videos in the queue

### DIFF
--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 
 import { joinArtists } from "../utils";
 import { setQueue } from "../store/queue/actions";
-import { Post } from "../store/list/types";
+import { FeedListType, Post } from "../store/list/types";
 
 import { Heart } from "react-feather";
 
@@ -17,6 +17,7 @@ type CardProps = {
   onClick?: Function;
   gkey?: string;
   listName?: string;
+  type: FeedListType;
 };
 
 export default function Card(props: CardProps) {
@@ -30,7 +31,7 @@ export default function Card(props: CardProps) {
         if (props.onClick !== undefined) {
           props.onClick();
         } else if (props.redirect === true) {
-          dispatch(setQueue(props.queue));
+          dispatch(setQueue(props.queue, props.type));
           history.push("/video?=" + props.id);
         }
       }}

--- a/src/components/feed-card.tsx
+++ b/src/components/feed-card.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from "react-redux";
 
 import { joinArtists } from "../utils";
 import { setQueue } from "../store/queue/actions";
-import { Post } from "../store/list/types";
+import { FeedListType, Post } from "../store/list/types";
 
 import { Heart } from "react-feather";
 
@@ -29,7 +29,7 @@ export default function FeedCard(props: CardProps) {
     if (props.onClick !== undefined) {
       props.onClick();
     } else if (props.redirect === true) {
-      dispatch(setQueue(props.queue));
+      dispatch(setQueue(props.queue, FeedListType.latest));
       history.push("/video?=" + props.id);
     }
   };

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -86,7 +86,14 @@ export const List = ({ title, type, redirect }: ListProps) => {
       ) : (
         <VArray className="array" id={title.trim()} len={videoList.length}>
           {videoList.map((vid) => (
-            <Card id={vid.id} key={vid.id + title.trim()} data={vid} queue={videoList} redirect={redirect} />
+            <Card
+              id={vid.id}
+              key={vid.id + title.trim()}
+              data={vid}
+              queue={videoList}
+              redirect={redirect}
+              type={type}
+            />
           ))}
         </VArray>
       )}

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
 import React, { useState, useEffect, useCallback } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Helmet } from "react-helmet";
 import YouTube from "react-youtube";
 
+import { getSongList } from "../store/list/effects";
+import { FeedListType } from "../store/list/types";
 import { mobileCheck } from "../utils/video";
 import { joinArtists } from "../utils";
 import { filterGenres } from "../utils/filterList";
@@ -18,10 +20,11 @@ interface VideoProps {
 }
 
 export const Video = (props: VideoProps) => {
-  let preQueue = useSelector((state: FalconRootState) => state.queue.posts);
-  let [queue] = useState(preQueue);
+  let dispatch = useDispatch();
+  let { type, posts } = useSelector((state: FalconRootState) => state.queue);
+  let [queue] = useState(posts);
 
-  if (preQueue.length === 0) {
+  if (posts.length === 0) {
     if (window !== undefined) {
       var home = window.location.protocol + "//" + window.location.host;
       if (window.history.pushState) {
@@ -42,7 +45,7 @@ export const Video = (props: VideoProps) => {
   let [currentIndex, changeIndex] = useState(
     (() => {
       if (props.id) {
-        return preQueue.map((e) => e.id).indexOf(props.id);
+        return posts.map((e) => e.id).indexOf(props.id);
       }
       return 0;
     })()
@@ -105,9 +108,15 @@ export const Video = (props: VideoProps) => {
   }, [currentIndex]);
 
   let playNextVideo = useCallback(() => {
-    if (queue.length > 0 && currentIndex + 1 < queue.length) {
-      changeURLid(queue[currentIndex + 1].id);
-      changeIndex(currentIndex + 1);
+    if (queue.length > 0) {
+      if (currentIndex + 1 < queue.length) {
+        changeURLid(queue[currentIndex + 1].id);
+        changeIndex(currentIndex + 1);
+      } else {
+        // Fetch the songs of the current list type
+        // append the songs to the queue
+        // Play the next song
+      }
     }
   }, [queue, currentIndex]);
 
@@ -235,6 +244,7 @@ export const Video = (props: VideoProps) => {
                 id={vid.id}
                 key={vid.id + "Queue-xyppu"}
                 data={vid}
+                type={type}
                 className={"queueCard" + selectClass}
                 redirect={false}
                 onClick={() => {

--- a/src/store/queue/action.types.ts
+++ b/src/store/queue/action.types.ts
@@ -1,6 +1,9 @@
-import { Post } from "../list/types";
+import { FeedListType, Post } from "../list/types";
 
 export type QueueAction = {
   type: string;
-  payload: Post[];
+  payload: {
+    type: FeedListType;
+    posts: Post[];
+  };
 };

--- a/src/store/queue/actions.ts
+++ b/src/store/queue/actions.ts
@@ -1,9 +1,9 @@
 import { QueueAction } from "./action.types";
-import { Post } from "../list/types";
+import { FeedListType, Post } from "../list/types";
 
-export const setQueue = (list: Post[]): QueueAction => {
+export const setQueue = (list: Post[], type: FeedListType): QueueAction => {
   return {
     type: "new queue",
-    payload: list,
+    payload: { type, posts: list },
   };
 };

--- a/src/store/queue/reducer.ts
+++ b/src/store/queue/reducer.ts
@@ -1,19 +1,23 @@
 import { Reducer } from "redux";
+import { FeedListType } from "../list/types";
 
 import { QueueAction } from "./action.types";
 import { QUEUE_ADD, QUEUE_RESET } from "./constants";
 import { QueueState } from "./types";
 
 let initialQueueState: QueueState = {
+  // TODO: Find a better way to represent no type state
+  // (Although this gets overwritten in the first update)
+  type: FeedListType.latest,
   posts: [],
 };
 
 export const queueReducer: Reducer<QueueState, QueueAction> = (state = initialQueueState, action): QueueState => {
   switch (action.type) {
     case QUEUE_ADD:
-      return { posts: [...state.posts, ...action.payload] };
+      return { type: action.payload.type, posts: [...state.posts, ...action.payload.posts] };
     case QUEUE_RESET:
-      return { posts: action.payload };
+      return { type: action.payload.type, posts: action.payload.posts };
     default:
       return state;
   }

--- a/src/store/queue/types.ts
+++ b/src/store/queue/types.ts
@@ -1,5 +1,6 @@
-import { Post } from "../list/types";
+import { FeedListType, Post } from "../list/types";
 
 export interface QueueState {
+  type: FeedListType;
   posts: Post[];
 }


### PR DESCRIPTION
This PR will add the following feature:

### **Load the next set of videos in queue.**

By queue I mean when the video is being played, the queue for next videos to be played.

This can happen with several interactions: 

- When the last video or close to the last video is played in the queue.
- When the user scrolls to the bottom of the queue 
  - infinite scroll
  - loading button for next videos

The first problem is a bit easier, we fetch the next set of videos when the last video starts to play or ends.

The second problem has two solutions:
1. **Infinite Scroll** 
_Pros_: Smoother UX, Feels modern. 
_Cons_: Addictive, "Unethical" (We don't have anything to gain by watchtime increase but users waste more time searching/waiting for a good video to show up), a little harder to implement and manage.

2. **Loading Button**
_Pros_:  Ethical, saves time, easier to implement and debug. 
_Cons_: Feels older.

Apart from the UX there are a few other difficulties as well:

**The Video component and Queue in Store don't have a FeedType.**

This is required because while loading the next set of videos we want the FeedType from which to load the video.

**The Lists and Queue in the reducers serve the same purpose.**

The current approach is to load the data from API into the lists and then fill the Queue whenever the user starts a Video. 
Due to this there is duplicate data present in queue. As the state of the queue visible in the component is different from that stored in the redux store, the state of the redux store is useless. The Queue is just another step in between the Store's lists and the local state queue in the component.

This affects the problem in hand because when we need to fetch new videos to add to the list, we have to:
1. Fetch them from API which get added to the list.
2. Add the videos from the list to the queue.
3. Update the local state queue with the queue from the store.

Instead of this, we can store a current playing list type variable and simply update the local queue of the component with the list of that type. Fetching new videos to add to the queue will be simplified: The new videos get added to the list, the local queue is updated with the list.

In the spirit of simplifying, I have added the type of the current list in the queue. With some modification we can remove the posts variable and then it would resemble my suggestion above. Afaik, there are no specific usecases that  require us to have a separate queue in the redux store. As this requires some thought and discussion, I have described the change here before implementing it. 

Please review the idea, I will start on the feature as soon as we land on a consensus.

This PR will fix #50 
