### PR TITLE
Minor visual tweaks to controls and links

### DIFF
--- a/src/styles/video.scss
+++ b/src/styles/video.scss
@@ -148,7 +148,9 @@
       }
     }
     .control_button {
-      padding: 0.5rem;
+      padding: 0.5rem 0.5rem 1rem;
+      display: flex;
+      align-items: center;
       &:hover {
         cursor: pointer;
         color: $primary;
@@ -176,6 +178,7 @@
     }
     .widgets {
       max-width: 300px;
+      display: flex;
       @include sm {
         transition: all ease-in-out 0.5s;
         margin-left: -0.5rem;


### PR DESCRIPTION
Visually centered the buttons and links.

Before:
![Screenshot_2020-12-29 LTTKGP 🎶 🎶 🎶(2)](https://user-images.githubusercontent.com/25076171/103237480-bad95400-496d-11eb-896a-f9c24acf033e.png)

After:
![Screenshot_2020-12-29 LTTKGP 🎶 🎶 🎶(1)](https://user-images.githubusercontent.com/25076171/103237488-bf9e0800-496d-11eb-8a8e-3c3cb7328804.png)


This small PR is just to cure my OCD.

These work just as well for posts with no tags or artist name.